### PR TITLE
Support Python 3.9+

### DIFF
--- a/cryptanalysis/search.py
+++ b/cryptanalysis/search.py
@@ -14,8 +14,6 @@ import math
 import os
 import time
 
-from fractions import gcd
-
 
 def computeProbabilityOfDifferentials(cipher, parameters):
     """
@@ -100,7 +98,7 @@ def findBestConstants(cipher, parameters):
                                                              beta])
                 continue
             #Filter gcd(alpha - beta, n) != 1 cases
-            if gcd(alpha - beta, wordsize) != 1:
+            if math.gcd(alpha - beta, wordsize) != 1:
                 constantMinWeights.append(1)
                 continue
 


### PR DESCRIPTION
fractions.gcd(a, b) has been moved to math.gcd(a, b) in Python 3.9.